### PR TITLE
Added seed option for WAIC2 computation for reproducibility

### DIFF
--- a/bayes_traj/bayes_traj_main.py
+++ b/bayes_traj/bayes_traj_main.py
@@ -112,6 +112,8 @@ def main():
         data set.', action='store_true')
     parser.add_argument('-s', help='Number of samples to use when computing \
         WAIC2', type=int, default=100)
+    parser.add_argument('--seed', help='Seed to use for WAIC2 \
+        sampling', type=int, default=None)
 #    parser.add_argument('--use_pyro', help='Use Pyro for inference',
 #        action='store_true')
     
@@ -276,7 +278,7 @@ def main():
             if op.out_model is not None:
                 torch.save(model, op.out_model)
 
-        waic2 = mm.compute_waic2(op.s)
+        waic2 = mm.compute_waic2(op.s, op.seed)
                 
         if False: #op.use_pyro:
             pass

--- a/bayes_traj/mult_dp_regression.py
+++ b/bayes_traj/mult_dp_regression.py
@@ -1398,7 +1398,7 @@ class MultDPRegression:
         else:
             return bic_obs
 
-    def compute_waic2(self, S=100):
+    def compute_waic2(self, S=100, seed=None):
         """Computes the Watanabe-Akaike (aka widely available) information
         criterion, using the variance of individual terms in the log predictive
         density summed over the n data points.
@@ -1410,6 +1410,9 @@ class MultDPRegression:
         S : integer, optional
             The number of draws from the posterior to use when computing the
             required expectations.
+        seed : int, optional
+            The seed to use for reproducibility. If None, the default
+            random seed will be used.
 
         Returns
         -------
@@ -1420,6 +1423,10 @@ class MultDPRegression:
         ----------
         Gelman et al, 'Bayesian Data Analysis, 3rd Edition'
         """
+        if seed is not None:
+            torch.manual_seed(seed)
+            np.random.seed(seed)
+
         if 'N_to_G_index_map_' not in dir(self):
             self._set_N_to_G_index_map()            
         

--- a/bayes_traj/summarize_traj_model.py
+++ b/bayes_traj/summarize_traj_model.py
@@ -26,6 +26,8 @@ def main():
         several moments to compute.', action="store_true")
     parser.add_argument('-s', help='Number of samples to use when computing \
         WAIC2', type=int, default=100)
+    parser.add_argument('--seed', help='Seed to use for WAIC2 \
+            sampling', type=int, default=None)
     
     op = parser.parse_args()
     
@@ -51,7 +53,7 @@ def main():
         bic = mm.bic()
         assert isinstance(op.s, int), 'Number of samples must be an integer.'
         assert op.s > 0, 'Number of samples must be greater than 0.'
-        waic2 = mm.compute_waic2(op.s)
+        waic2 = mm.compute_waic2(op.s, op.seed)
     
     # Compute fit stats
     ave_pps = ave_pp(mm)


### PR DESCRIPTION
Included an option to set a seed in bayes_traj_main and summarize_traj for reproducibility of the WAIC2-score. If None, the default random seed will be used.